### PR TITLE
特定の操作をした時にタスクが上書きされるバグを修正

### DIFF
--- a/NotificationTask.xcodeproj/project.pbxproj
+++ b/NotificationTask.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ja,
 			);
 			mainGroup = 1B9B67BA2991192100142245;
 			productRefGroup = 1B9B67C42991192100142245 /* Products */;

--- a/NotificationTask.xcodeproj/xcuserdata/maguchihideto.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/NotificationTask.xcodeproj/xcuserdata/maguchihideto.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -15,5 +15,13 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>1B9B67C22991192100142245</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/NotificationTask/ContentView.swift
+++ b/NotificationTask/ContentView.swift
@@ -94,7 +94,9 @@ struct ContentView: View {
                 }
             }
         }
-        .sheet(isPresented: $isSetTaskShow){
+        .sheet(isPresented: $isSetTaskShow, onDismiss: {
+            indexToDelete = Int.max
+        }){
             SetTaskView(titleText: $titleText, indexToDelete: $indexToDelete, selectedDay: $selectedDay)
             //モーダルをどこまで表示させるか指定
                 .presentationDetents([.fraction(0.20)])
@@ -120,7 +122,6 @@ struct ContentView: View {
             let nsError = error as NSError
             fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
         }
-        indexToDelete = Int.max
         //レビューの依頼（一度のみ）
         if DidAppStoreReviewRequested == false {
             requestReview()

--- a/NotificationTask/SetTaskView.swift
+++ b/NotificationTask/SetTaskView.swift
@@ -30,6 +30,31 @@ struct SetTaskView: View {
                     .padding()
                     .focused($focus)
                     .onSubmit { startTask() }
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                                Button(action: {
+                                    dismiss()
+                                }) {
+                                    Text("閉じる")
+                                }
+                                
+                                
+                                Button(action: {
+                                    startTask()
+                                }) {
+                                    Text("開始")
+                                        .padding(5)
+                                        .foregroundColor(.white)
+                                        .background(Color("AccentColor"))
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 5)
+                                                .stroke(Color("AccentColor"), lineWidth: 2)
+                                        )
+                                }
+                                
+                            
+                        }
+                    }
                 Text("いつまでに終わらせる？")
                     .padding(.horizontal, 10)
                     .opacity(0.7)
@@ -40,32 +65,6 @@ struct SetTaskView: View {
                 }
                 .padding(.horizontal)
                 .pickerStyle(.segmented)
-                Spacer()
-                HStack {
-                    Button(action: {
-                        dismiss()
-                    }) {
-                        Text("閉じる")
-                    }
-                    
-                    Spacer()
-                    
-                    Button(action: {
-                        startTask()
-                    }) {
-                        Text("開始")
-                            .padding(5)
-                            .foregroundColor(.white)
-                            .background(Color("AccentColor"))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 5)
-                                    .stroke(Color("AccentColor"), lineWidth: 2)
-                            )
-                    }
-                    
-                }
-                .padding(.horizontal)
-                .padding(.bottom)
             }
         }
         .onAppear() { focus = true }

--- a/NotificationTask/ViewModel.swift
+++ b/NotificationTask/ViewModel.swift
@@ -7,7 +7,6 @@
 import SwiftUI
 import CoreData
 
-//coreData,通知に関する処理
 final class DataControl: ObservableObject {
     @Published var createdAt =  Date()
     @Published var selectedDay = "なし"


### PR DESCRIPTION
以下の操作をした場合、既存のタスクが上書きされて新規タスクが登録されてしまっていたので修正
1.タスクを選択
2.モーダル外をタップして何もせずモーダルを閉じる
3.新規タスク作成

修正方法：
indexToDeleteをInt.maxに変更する際のトリガーを「モーダルを閉じた時」に統一
